### PR TITLE
fix(http): add request.RemoteAddr in case of WithClientIP

### DIFF
--- a/http.go
+++ b/http.go
@@ -2,10 +2,12 @@ package accesslog
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/middleware"
@@ -119,6 +121,8 @@ func (le *DefaultHTTPLogEntry) Write(t time.Time) {
 
 	if le.cfg.withClientIP {
 		if ip := clientIP(le.r.Header); ip != "" {
+			e.Str("client-ip", ip)
+		} else if ip, _, err := net.SplitHostPort(strings.TrimSpace(le.r.RemoteAddr)); err == nil {
 			e.Str("client-ip", ip)
 		}
 	}

--- a/http_option.go
+++ b/http_option.go
@@ -1,7 +1,6 @@
 package accesslog
 
 import (
-	"net/http"
 	"strings"
 )
 
@@ -54,29 +53,4 @@ func WithClientIP() httpOption {
 	return func(cfg *httpConfig) {
 		cfg.withClientIP = true
 	}
-}
-
-var (
-	trueClientIP          = http.CanonicalHeaderKey("True-Client-IP")
-	xForwardedFor         = http.CanonicalHeaderKey("X-Forwarded-For")
-	xRealIP               = http.CanonicalHeaderKey("X-Real-IP")
-	xEnvoyExternalAddress = http.CanonicalHeaderKey("X-Envoy-External-Address")
-)
-
-func clientIP(h http.Header) string {
-	if tcip := h.Get(trueClientIP); tcip != "" {
-		return tcip
-	} else if xrip := h.Get(xRealIP); xrip != "" {
-		return xrip
-	} else if xff := h.Get(xForwardedFor); xff != "" {
-		i := strings.Index(xff, ",")
-		if i == -1 {
-			i = len(xff)
-		}
-		return xff[:i]
-	} else if xeea := h.Get(xEnvoyExternalAddress); xeea != "" {
-		return xeea
-	}
-
-	return ""
 }

--- a/http_option_test.go
+++ b/http_option_test.go
@@ -1,6 +1,7 @@
 package accesslog
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 )
@@ -58,6 +59,50 @@ func Test_headerMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := headerMap(tt.hs); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("headerMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_clientIP(t *testing.T) {
+	tests := []struct {
+		name string
+		h    http.Header
+		want string
+	}{
+		{
+			name: "true-client-ip",
+			h: http.Header{
+				"True-Client-Ip": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+		{
+			name: "x-forwarded-for",
+			h: http.Header{
+				"X-Forwarded-For": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+		{
+			name: "x-real-ip",
+			h: http.Header{
+				"X-Real-Ip": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+		{
+			name: "x-envoy-external-address",
+			h: http.Header{
+				"X-Envoy-External-Address": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clientIP(tt.h); got != tt.want {
+				t.Errorf("clientIP() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/http_option_test.go
+++ b/http_option_test.go
@@ -1,7 +1,6 @@
 package accesslog
 
 import (
-	"net/http"
 	"reflect"
 	"testing"
 )
@@ -59,50 +58,6 @@ func Test_headerMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := headerMap(tt.hs); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("headerMap() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_clientIP(t *testing.T) {
-	tests := []struct {
-		name string
-		h    http.Header
-		want string
-	}{
-		{
-			name: "true-client-ip",
-			h: http.Header{
-				"True-Client-Ip": []string{"255.255.255.255"},
-			},
-			want: "255.255.255.255",
-		},
-		{
-			name: "x-forwarded-for",
-			h: http.Header{
-				"X-Forwarded-For": []string{"255.255.255.255"},
-			},
-			want: "255.255.255.255",
-		},
-		{
-			name: "x-real-ip",
-			h: http.Header{
-				"X-Real-Ip": []string{"255.255.255.255"},
-			},
-			want: "255.255.255.255",
-		},
-		{
-			name: "x-envoy-external-address",
-			h: http.Header{
-				"X-Envoy-External-Address": []string{"255.255.255.255"},
-			},
-			want: "255.255.255.255",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := clientIP(tt.h); got != tt.want {
-				t.Errorf("clientIP() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -26,7 +26,7 @@ func TestDefaultHTTPLogEntry_isIgnored(t *testing.T) {
 				},
 				r: &http.Request{
 					Method: "GET",
-					URL: &url.URL{Path: "/abc"},
+					URL:    &url.URL{Path: "/abc"},
 				},
 			},
 			want: true,
@@ -41,7 +41,7 @@ func TestDefaultHTTPLogEntry_isIgnored(t *testing.T) {
 				},
 				r: &http.Request{
 					Method: "POST",
-					URL: &url.URL{Path: "/abc"},
+					URL:    &url.URL{Path: "/abc"},
 				},
 			},
 			want: false,
@@ -130,6 +130,50 @@ func TestDefaultHTTPLogEntry_isIgnored(t *testing.T) {
 			}
 			if got := le.isIgnored(); got != tt.want {
 				t.Errorf("isIgnored() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_clientIP(t *testing.T) {
+	tests := []struct {
+		name string
+		h    http.Header
+		want string
+	}{
+		{
+			name: "true-client-ip",
+			h: http.Header{
+				"True-Client-Ip": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+		{
+			name: "x-forwarded-for",
+			h: http.Header{
+				"X-Forwarded-For": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+		{
+			name: "x-real-ip",
+			h: http.Header{
+				"X-Real-Ip": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+		{
+			name: "x-envoy-external-address",
+			h: http.Header{
+				"X-Envoy-External-Address": []string{"255.255.255.255"},
+			},
+			want: "255.255.255.255",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clientIP(tt.h); got != tt.want {
+				t.Errorf("clientIP() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
If no header that determines the real user's IP is found, the RemoteIP of the request should be output.